### PR TITLE
Added Support for Chat Metadata

### DIFF
--- a/src/chat/chat-create.dto.ts
+++ b/src/chat/chat-create.dto.ts
@@ -56,4 +56,18 @@ export class CreateChatDTO {
   @IsOptional()
   @Length(1, 255)
   username?: string;
+
+  /**
+   * Additional metadata for the chat.
+   * This field can store any additional information that needs to be associated with the chat.
+   * It is allowed to be null.
+   *
+   * @ApiPropertyOptional - Documents this property in Swagger as optional, indicating its role and constraints.
+   * @IsOptional - Indicates that the metadata is not a required field.
+   */
+  @ApiPropertyOptional({
+    description: 'Additional metadata for the chat',
+  })
+  @IsOptional()
+  metadata?: Record<string, any>;
 }

--- a/src/chat/chat-find-response.dto.ts
+++ b/src/chat/chat-find-response.dto.ts
@@ -36,6 +36,16 @@ export class FindChatsResponseDTO extends FindResponseDTO {
   username?: string;
 
   /**
+   * The metadata associated with the chat.
+   * This field, if provided during chat creation, includes additional information about the chat.
+   * It is included in the response to provide context about the chat's contents or purpose.
+   *
+   * @ApiPropertyOptional - Documents this property in Swagger as optional, indicating its role and presence in the response.
+   */
+  @ApiPropertyOptional({ description: 'Additional metadata for the chat' })
+  metadata?: Record<string, any>;
+
+  /**
    * The actual data of the response, consisting of an array of chat details.
    * Each element in the array is an instance of ChatResponseDTO.
    *

--- a/src/chat/chat-response.dto.ts
+++ b/src/chat/chat-response.dto.ts
@@ -64,4 +64,14 @@ export class ChatResponseDTO {
    */
   @ApiPropertyOptional({ description: 'Username associated with the chat' })
   username?: string;
+
+  /**
+   * The metadata associated with the chat.
+   * This field, if provided during chat creation, includes additional information about the chat.
+   * It is included in the response to provide context about the chat's contents or purpose.
+   *
+   * @ApiPropertyOptional - Documents this property in Swagger as optional, indicating its role and presence in the response.
+   */
+  @ApiPropertyOptional({ description: 'Additional metadata for the chat' })
+  metadata?: Record<string, any>;
 }

--- a/src/chat/chat.entity.ts
+++ b/src/chat/chat.entity.ts
@@ -92,4 +92,11 @@ export class Chat {
   @Index()
   @Column({ type: 'varchar', length: 255, nullable: true })
   username: string | null;
+
+  /**
+   * Optional metadata associated with the chat.
+   * This field can store any additional information about the chat session.
+   */
+  @Column({ type: 'jsonb', default: {} })
+  metadata: Record<string, any>;
 }

--- a/src/conversation/conversation-response.dto.ts
+++ b/src/conversation/conversation-response.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 /**
  * Data Transfer Object (DTO) for responses within a conversation.
@@ -15,6 +15,16 @@ export class ConversationResponseDTO {
    */
   @ApiProperty({ description: 'Unique ID of the chat.' })
   chatId: string;
+
+  /**
+   * The metadata associated with the chat.
+   * This field, if provided during chat creation, includes additional information about the chat.
+   * It is included in the response to provide context about the chat's contents or purpose.
+   *
+   * @ApiPropertyOptional - Documents this property in Swagger as optional, indicating its role and presence in the response.
+   */
+  @ApiPropertyOptional({ description: 'Additional metadata for the chat' })
+  metadata?: Record<string, any>;
 
   /**
    * The response message in the conversation.

--- a/src/conversation/conversation-start.dto.ts
+++ b/src/conversation/conversation-start.dto.ts
@@ -94,4 +94,15 @@ export class StartConversationDTO {
   @IsOptional()
   @Length(1, 255)
   username?: string;
+
+  /**
+   * The metadata associated with the chat.
+   * This field, if provided during chat creation, includes additional information about the chat.
+   * It is included in the response to provide context about the chat's contents or purpose.
+   *
+   * @ApiPropertyOptional - Documents this property in Swagger as optional, indicating its role and presence in the response.
+   */
+  @ApiPropertyOptional({ description: 'Additional metadata for the chat' })
+  @IsOptional()
+  metadata?: Record<string, any>;
 }

--- a/src/conversation/conversation.controller.ts
+++ b/src/conversation/conversation.controller.ts
@@ -206,6 +206,7 @@ export class ConversationController {
               'Chat created successfully, message stored and AI response sent back',
             data: {
               chatId: chat.id,
+              metadata: chat.metadata,
               response,
             },
           }),
@@ -320,6 +321,7 @@ export class ConversationController {
             message: 'Message stored and AI response sent back',
             data: {
               chatId,
+              metadata: chat.metadata,
               response,
             },
           }),

--- a/src/message/message-find-response.dto.ts
+++ b/src/message/message-find-response.dto.ts
@@ -28,6 +28,16 @@ export class FindMessagesResponseDTO extends FindResponseDTO {
   role?: MessageRoles;
 
   /**
+   * The metadata associated with the chat.
+   * This field, if provided during chat creation, includes additional information about the chat.
+   * It is included in the response to provide context about the chat's contents or purpose.
+   *
+   * @ApiPropertyOptional - Documents this property in Swagger as optional, indicating its role and presence in the response.
+   */
+  @ApiPropertyOptional({ description: 'Additional metadata for the chat' })
+  metadata?: Record<string, any>;
+
+  /**
    * The actual data of the response, consisting of an array of message details.
    * Each element in the array is an instance of MessageResponseDTO.
    *


### PR DESCRIPTION
This PR adds support for a JSON Metadata field in the chat entity.

- Metadata is returned with requests to `/conversations` and `/chats/:chatId`
- Metadata can be added during the initial chat creation via `/conversations/start`